### PR TITLE
Add HTTP fax server example

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,23 @@ System.out.println("Fax job submitted, ID: "+faxJob.getID());
 
 You can see more examples and a tutorial at: [javadocs](https://sagiegurari.github.io/fax4j/apidocs/overview-summary.html#overview_description)
 
+## HTTP Fax Server
+
+An example Spring Boot server is available under `server/http` exposing a minimal HTTP API on top of fax4j.
+
+* `POST /fax` – submit a fax job using multipart form data. Expected fields include at least `file`, `filename` and `targetaddress`.
+* `GET /fax/{id}` – query the status of a previously submitted fax job.
+
+Sample requests:
+
+```bash
+# submit a fax
+curl -F "file=@/path/to/myfax.txt" -F "filename=myfax.txt" -F "targetaddress=555-555" http://localhost:8080/fax
+
+# check status
+curl http://localhost:8080/fax/<fax-id>
+```
+
 ## Building from Sources
 
 The fax4j library comes with a maven pom.xml which can be used to build the Java layer of the library.

--- a/server/http/README.md
+++ b/server/http/README.md
@@ -1,0 +1,24 @@
+# HTTP Fax Server
+
+This module provides a minimal Spring Boot based HTTP bridge for fax4j.
+
+## Running
+
+```bash
+mvn spring-boot:run
+```
+
+## API
+
+* `POST /fax` – submit a fax job using multipart form data. Required fields: `file`, `filename`, and `targetaddress`.
+* `GET /fax/{id}` – retrieve fax job status.
+
+### Sample requests
+
+```bash
+# submit a fax
+curl -F "file=@/path/to/myfax.txt" -F "filename=myfax.txt" -F "targetaddress=555-555" http://localhost:8080/fax
+
+# check status
+curl http://localhost:8080/fax/<fax-id>
+```

--- a/server/http/pom.xml
+++ b/server/http/pom.xml
@@ -1,0 +1,38 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>net.sf.fax4j</groupId>
+  <artifactId>fax4j-http-server</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <properties>
+    <java.version>17</java.version>
+    <spring.boot.version>3.2.5</spring.boot.version>
+  </properties>
+  <dependencies>
+    <dependency>
+      <groupId>net.sf.fax4j</groupId>
+      <artifactId>fax4j</artifactId>
+      <version>0.45.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${spring.boot.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring.boot.version}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${spring.boot.version}</version>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/server/http/src/main/java/org/fax4j/server/http/FaxController.java
+++ b/server/http/src/main/java/org/fax4j/server/http/FaxController.java
@@ -1,0 +1,101 @@
+package org.fax4j.server.http;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.fax4j.FaxClient;
+import org.fax4j.FaxClientFactory;
+import org.fax4j.FaxJob;
+import org.fax4j.FaxJobStatus;
+import org.fax4j.bridge.http.HTTP2FaxBridge;
+import org.fax4j.spi.http.HTTPRequest;
+import org.fax4j.spi.http.HTTPRequest.ContentPart;
+import org.fax4j.spi.http.HTTPRequest.ContentPartType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * Simple controller exposing fax operations over HTTP.
+ */
+@RestController
+@RequestMapping("/fax")
+public class FaxController {
+    private final HTTP2FaxBridge bridge;
+    private final FaxClient faxClient;
+    private final Map<String, FaxJob> jobs = new ConcurrentHashMap<>();
+
+    public FaxController() {
+        this.bridge = new HTTP2FaxBridge();
+        this.bridge.initialize(null, null, this);
+        // fax client for querying job status
+        this.faxClient = FaxClientFactory.createFaxClient();
+    }
+
+    @PostMapping
+    public Map<String, String> submitFax(@RequestPart("file") MultipartFile file,
+            @RequestParam("targetaddress") String targetAddress,
+            @RequestParam(value = "filename", required = false) String fileName,
+            @RequestParam(value = "priority", required = false) String priority,
+            @RequestParam(value = "targetname", required = false) String targetName,
+            @RequestParam(value = "sendername", required = false) String senderName,
+            @RequestParam(value = "senderfaxnumber", required = false) String senderFaxNumber,
+            @RequestParam(value = "senderemail", required = false) String senderEmail) throws IOException {
+        List<ContentPart<?>> parts = new ArrayList<>();
+        parts.add(new ContentPart<>("file", file.getBytes(), ContentPartType.BINARY));
+        String finalName = fileName != null ? fileName : file.getOriginalFilename();
+        if (finalName != null) {
+            parts.add(new ContentPart<>("filename", finalName, ContentPartType.STRING));
+        }
+        parts.add(new ContentPart<>("targetaddress", targetAddress, ContentPartType.STRING));
+        if (priority != null) {
+            parts.add(new ContentPart<>("priority", priority, ContentPartType.STRING));
+        }
+        if (targetName != null) {
+            parts.add(new ContentPart<>("targetname", targetName, ContentPartType.STRING));
+        }
+        if (senderName != null) {
+            parts.add(new ContentPart<>("sendername", senderName, ContentPartType.STRING));
+        }
+        if (senderFaxNumber != null) {
+            parts.add(new ContentPart<>("senderfaxnumber", senderFaxNumber, ContentPartType.STRING));
+        }
+        if (senderEmail != null) {
+            parts.add(new ContentPart<>("senderemail", senderEmail, ContentPartType.STRING));
+        }
+
+        HTTPRequest request = new HTTPRequest();
+        request.setContent(parts.toArray(new ContentPart<?>[0]));
+
+        FaxJob faxJob = this.bridge.submitFaxJob(request);
+        String id = faxJob.getID();
+        this.jobs.put(id, faxJob);
+
+        Map<String, String> response = new HashMap<>();
+        response.put("id", id);
+        return response;
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Map<String, String>> getStatus(@PathVariable("id") String id) {
+        FaxJob faxJob = this.jobs.get(id);
+        if (faxJob == null) {
+            return ResponseEntity.notFound().build();
+        }
+        FaxJobStatus status = this.faxClient.getFaxJobStatus(faxJob);
+        Map<String, String> response = new HashMap<>();
+        response.put("id", id);
+        response.put("status", status.name());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/server/http/src/main/java/org/fax4j/server/http/HttpFaxServerApplication.java
+++ b/server/http/src/main/java/org/fax4j/server/http/HttpFaxServerApplication.java
@@ -1,0 +1,14 @@
+package org.fax4j.server.http;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/**
+ * Entry point for the example HTTP fax server.
+ */
+@SpringBootApplication
+public class HttpFaxServerApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(HttpFaxServerApplication.class, args);
+    }
+}


### PR DESCRIPTION
## Summary
- add new `server/http` module with Spring Boot fax controller and application
- document HTTP fax API and sample requests in README

## Testing
- `mvn -q test` *(fails: Unresolveable build extension: Plugin org.sonatype.plugins:nexus-staging-maven-plugin:jar:1.6.12)*
- `mvn -q -f server/http/pom.xml test` *(fails: Plugin org.apache.maven.plugins:maven-resources-plugin:3.3.1 could not be resolved: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68aa46c2ae3083238f0d5012910a89ae