### PR TITLE
Add JDK check to install script

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+set -e
+
+# Check for JDK presence
+if command -v javac >/dev/null 2>&1; then
+  echo "JDK found: $(javac -version 2>&1)"
+elif [ -n "$JAVA_HOME" ] && [ -x "$JAVA_HOME/bin/javac" ]; then
+  echo "Using JDK from JAVA_HOME: $JAVA_HOME"
+else
+  echo "Error: JDK not found. Please install a JDK (e.g., 'sudo apt install openjdk-17-jdk') and rerun this script." >&2
+  exit 1
+fi
+
+# Run the build
+./build.sh


### PR DESCRIPTION
## Summary
- add an install script that checks for a JDK via `javac` or `JAVA_HOME` and guides installation if missing

## Testing
- `./install.sh` *(fails: Unresolveable build extension: Plugin org.sonatype.plugins:nexus-staging-maven-plugin:1.6.12)*

------
https://chatgpt.com/codex/tasks/task_e_68aa9803a6688323adf4116267fe651b